### PR TITLE
Removes non-JS jokes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,6 @@ A: Because its parent kept giving it props!
 
 ---
 
-Friend: you both look like a cute couple!! where did you find her? tinder or insta?
-
-Me: GITHUB
-
----
-
-Programmer 1: We have a problem!  
-Programmer 2: Let's use RegEx!  
-Programmer 1: Now we have two problems.
-
----
-
-My girlfriend dumped me after I named a class after her. She felt I treated her like an object.
-
----
-
 Sometimes when I'm writing JavaScript I want to throw up my hands and say "this is bullshit!" but I can never remember what "this" refers to.
 
 ---
@@ -69,16 +53,6 @@ Sometimes when I'm writing JavaScript I want to throw up my hands and say "this 
 Q: Why did the React class component feel relieved?
 
 A: Because it was now off the hook.
-
----
-
-There is no time to sharpen the saw, it is necessary to saw wood (about technical debt and manager's rush).
-
----
-
-Q: Which type of shooting always hurts the shooter?
-
-A: Trouble-shooting!
 
 ---
 
@@ -113,33 +87,9 @@ Me: Try console.log(console) in chrome console and explore the console 😎
 
 ---
 
-I and JavaScript in a Console:
-
-Me: `0 == "0"`?
-
-JS: `true`
-
-Me: `0 == []`?
-
-JS: `true`
-
-Me: If `0 == "0"` and `0 == []` are `true`, so `"0" == []`?
-
-JS: `false`
-
-ME: :cursing_face:
-
----
-
 Q: Why did the hungry dev multiply a string by an integer?
 
 A: He wanted some NaN bread
-
----
-
-Q: Why are 'i' and 'j' a good source of information?
-
-A: They're always in the loop
 
 ---
 
@@ -167,30 +117,6 @@ A: They overreact.
 
 ---
 
-Q: Why did the programmers quit?
-
-A: Because they didn’t get arrays.
-
----
-
-Q: What's Your Idea of a Perfect Date?
-
-A: YYYY-MM-DD,
-I find other Formates confusing.
-
----
-
-Debugging is like being the detective in a
-crime movie where you're also the murderer.
-
----
-
-Q: Whats the difference between Git and Github
-
-A: The same as Porn and Pornhub .
-
----
-
 Q: Why did the jQuery developer never have financial problems?
 
 A: Because he was in \$.noConflict() mode
@@ -200,12 +126,6 @@ A: Because he was in \$.noConflict() mode
 Q: Why was the JavaScript developer sad?
 
 A: Because he didn't Node how to Express himself.
-
-
----
-
-Q. Why was the JavaScript developer sad?
-   Because he didn't Node how to Express himself
 
 ---
  
@@ -233,8 +153,6 @@ Q. The three most well known languages in India are English, Hindi, and...
    JavaScript
 
 ---
-
-I have a HTTP joke but if I POST it here then you will not GET it.
 
 <img align="left" alt="GitHub" width="26px" src="https://raw.githubusercontent.com/github/explore/78df643247d429f6cc873026c0622819ad797942/topics/github/github.png" />is :heart:
 


### PR DESCRIPTION
First, I would like to say that this is a terrible way to get Hacktoberfest credits for anyone that is submitting these jokes to this repository (please feel free to mark this PR as `invalid` so I don't get credit for this one either). Second, if the intent of this repository is to collect jokes pertaining to JavaScript, there should be some criteria that the jokes are ACTUALLY relevant to JavaScript. This PR removes all of the jokes that had nothing to do with JavaScript as well as some duplicate jokes that I found.